### PR TITLE
chore: use mongo shell for querying mongoDB in tests

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -70,8 +70,6 @@ jobs:
 
       - name: unit test:coverage
         run: ./node_modules/.bin/lerna run test:coverage
-        env:
-          MONGO_CLIENT_PATH: /usr/bin/mongo
 
       - name: codecov
         env:

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -70,6 +70,8 @@ jobs:
 
       - name: unit test:coverage
         run: ./node_modules/.bin/lerna run test:coverage
+        env:
+          MONGO_CLIENT_PATH: /usr/bin/mongo
 
       - name: codecov
         env:

--- a/main/.eslintignore
+++ b/main/.eslintignore
@@ -1,2 +1,3 @@
 coverage
 lib
+tests/MongoFind.js

--- a/main/package.json
+++ b/main/package.json
@@ -44,7 +44,8 @@
     "@types/mongodb": "^3.5.27",
     "concurrently": "^5.3.0",
     "mongodb": "^3.6.2",
-    "mongodb-memory-server": "^6.7.5"
+    "mongodb-memory-server": "^6.7.5",
+    "tmp": "^0.2.1"
   },
   "lint-staged": {
     "src/**/*.ts": "eslint"

--- a/main/package.json
+++ b/main/package.json
@@ -17,6 +17,7 @@
     "watch:transpile": "babel -w src --out-dir lib --extensions '.ts' --ignore '**/*.test.ts' --ignore 'tests'",
     "watch:declaration": "tsc -w --declaration --outDir lib/ --rootDir src --emitDeclarationOnly --skipLibCheck --project tsconfig.build.json",
     "build": "npm run build:transpile && npm run build:declaration",
+    "build:mongoclient": "babel tests/MongoFind.ts --out-file tests/MongoFind.js --extensions '.ts'",
     "build:transpile": "babel --delete-dir-on-start src --out-dir lib --extensions '.ts' --ignore '**/*.test.ts' --ignore 'tests'",
     "build:declaration": "tsc --declaration --outDir lib/ --rootDir src --emitDeclarationOnly --skipLibCheck --project tsconfig.build.json",
     "precommit": "lint-staged",
@@ -44,8 +45,7 @@
     "@types/mongodb": "^3.5.27",
     "concurrently": "^5.3.0",
     "mongodb": "^3.6.2",
-    "mongodb-memory-server": "^6.7.5",
-    "tmp": "^0.2.1"
+    "mongodb-memory-server": "^6.7.5"
   },
   "lint-staged": {
     "src/**/*.ts": "eslint"

--- a/main/src/LinkChild.ts
+++ b/main/src/LinkChild.ts
@@ -141,13 +141,11 @@ export class LinkChild<
         case 'added': {
           if (!this.publicationContext.addedChildrenIds.has(q.payload.id))
             break;
-          // only add the dangling document when this instance is the primary
-          if (this.publicationContext.isPrimaryForChildId(q.payload.id)) {
-            this.publicationContext.added(
-              q.payload.id,
-              this.filterFields(q.payload.doc)
-            );
-          }
+
+          this.publicationContext.added(
+            q.payload.id,
+            this.filterFields(q.payload.doc)
+          );
           this.children.parentAdded(q.payload.id, q.payload.doc);
           break;
         }

--- a/main/src/LinkChildSelector.ts
+++ b/main/src/LinkChildSelector.ts
@@ -180,9 +180,6 @@ export class LinkChildSelector<
     queue.forEach((q) => {
       switch (q.type) {
         case 'parentAdded': {
-          // don't do anything if the parent has returned an equal matcher
-          if (this.queryResolver.has(q.payload.sourceId, q.payload.matcher))
-            break;
           this.queryResolver.add(q.payload.sourceId, q.payload.matcher);
           const keys = Object.values(this.queueDocs)
             .filter((doc) => q.payload.matcher.match(doc))
@@ -220,10 +217,7 @@ export class LinkChildSelector<
         }
         case 'changed': {
           const [matched, nonMatched] = this.queryResolver.match(q.payload.doc);
-          // if no matcher matches at all remove the child completely
-          if (!matched.length) {
-            this.publicationContext.removeChildFromRegistry(q.payload.id);
-          } else if (nonMatched.length) {
+          if (nonMatched.length) {
             // otherwise remove it for every sourceId which doesn't match
             // we don't care if the child is registered for that source
             // let the registry handle those cases
@@ -236,9 +230,6 @@ export class LinkChildSelector<
           matched.forEach((sourceId) => {
             this.publicationContext.addToRegistry(sourceId, [q.payload.id]);
           });
-
-          // if the child is not present at this step just ignore it
-          if (!this.publicationContext.hasChildId(q.payload.id)) break;
 
           this.publicationContext.changed(
             q.payload.id,
@@ -249,10 +240,7 @@ export class LinkChildSelector<
         }
         case 'replaced': {
           const [matched, nonMatched] = this.queryResolver.match(q.payload.doc);
-          // if no matcher matches at all remove the child completely
-          if (!matched.length) {
-            this.publicationContext.removeChildFromRegistry(q.payload.id);
-          } else if (nonMatched.length) {
+          if (nonMatched.length) {
             // otherwise remove it for every sourceId which doesn't match
             // we don't care if the child is registered for that source
             // let the registry handle those cases
@@ -265,9 +253,6 @@ export class LinkChildSelector<
           matched.forEach((sourceId) => {
             this.publicationContext.addToRegistry(sourceId, [q.payload.id]);
           });
-
-          // if the child is not present at this step just ignore it
-          if (!this.publicationContext.hasChildId(q.payload.id)) break;
 
           this.publicationContext.replaced(
             q.payload.id,

--- a/main/tests/MeteorCollectionMock.ts
+++ b/main/tests/MeteorCollectionMock.ts
@@ -1,0 +1,101 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+
+import { Collection, FilterQuery } from 'mongodb';
+import tmp from 'tmp';
+
+import { MongoDoc } from '../src/types';
+
+type FindOptions<T> = {
+  fields?: { [P in keyof T]: boolean | number };
+};
+
+const mongoPath = process.env.MONGO_CLIENT_PATH || 'mongo';
+
+const mongoExists = (): void => {
+  try {
+    execSync(`${mongoPath} --version`, {
+      encoding: 'utf8',
+    });
+  } catch (err) {
+    console.debug(err);
+    throw Error(
+      `could not find the mongo binary (ENV.MONGO_CLIENT_PATH: ${mongoPath})`
+    );
+  }
+};
+
+export class MeteorCollection<T extends MongoDoc> {
+  private readonly collection: Collection<T>;
+
+  private readonly timeout: number;
+
+  private readonly uri: string;
+
+  constructor(uri: string, collection: Collection<T>, timeout: number) {
+    mongoExists();
+    this.uri = uri;
+    this.collection = collection;
+    this.timeout = timeout;
+  }
+
+  public rawCollection = (): Collection<T> => this.collection;
+
+  // could find no way to get fibers play nicely with jest and async/await so:
+  // God please have mercy on me for the following
+  public find = jest
+    .fn()
+    .mockImplementation((query?: FilterQuery<T>, options?: FindOptions<T>):
+      | Array<Partial<T>>
+      | undefined => {
+      let q = `db.${this.collection.collectionName}`;
+      if (query) {
+        if (options?.fields) {
+          q = `${q}.find(${JSON.stringify(query)}, ${JSON.stringify(
+            options?.fields
+          )})`;
+        } else {
+          q = `${q}.find(${JSON.stringify(query)})`;
+        }
+      } else if (options?.fields) {
+        q = `${q}.find(${JSON.stringify({})}, ${JSON.stringify(
+          options?.fields
+        )})`;
+      } else {
+        q = `${q}.find()`;
+      }
+
+      q = `${q}.toArray()`;
+      q = `JSON.stringify(${q})`;
+
+      const tmpfile = tmp.fileSync();
+      fs.writeFileSync(tmpfile.name, q);
+
+      const run = `mongo --quiet --host ${this.uri} < ${tmpfile.name}`;
+
+      let result = '';
+      try {
+        result = execSync(run, {
+          encoding: 'utf8',
+        });
+      } catch (err) {
+        console.debug(`QUERY: ${q}`);
+        console.error(err);
+        throw err;
+      }
+
+      const lines = result.split('\n');
+
+      let res: Array<Partial<T>> | undefined;
+      lines.some((l) => {
+        try {
+          res = JSON.parse(l);
+          return true;
+        } catch (err) {
+          return false;
+        }
+      });
+
+      return res;
+    });
+}

--- a/main/tests/MeteorCollectionMock.ts
+++ b/main/tests/MeteorCollectionMock.ts
@@ -1,8 +1,7 @@
 import { execSync } from 'child_process';
-import fs from 'fs';
+import path from 'path';
 
 import { Collection, FilterQuery } from 'mongodb';
-import tmp from 'tmp';
 
 import { MongoDoc } from '../src/types';
 
@@ -10,20 +9,7 @@ type FindOptions<T> = {
   fields?: { [P in keyof T]: boolean | number };
 };
 
-const mongoPath = process.env.MONGO_CLIENT_PATH || 'mongo';
-
-const mongoExists = (): void => {
-  try {
-    execSync(`${mongoPath} --version`, {
-      encoding: 'utf8',
-    });
-  } catch (err) {
-    console.debug(err);
-    throw Error(
-      `could not find the mongo binary (ENV.MONGO_CLIENT_PATH: ${mongoPath})`
-    );
-  }
-};
+const scriptPath = path.join(__dirname, 'MongoFind.js');
 
 export class MeteorCollection<T extends MongoDoc> {
   private readonly collection: Collection<T>;
@@ -33,7 +19,6 @@ export class MeteorCollection<T extends MongoDoc> {
   private readonly uri: string;
 
   constructor(uri: string, collection: Collection<T>, timeout: number) {
-    mongoExists();
     this.uri = uri;
     this.collection = collection;
     this.timeout = timeout;
@@ -48,54 +33,28 @@ export class MeteorCollection<T extends MongoDoc> {
     .mockImplementation((query?: FilterQuery<T>, options?: FindOptions<T>):
       | Array<Partial<T>>
       | undefined => {
-      let q = `db.${this.collection.collectionName}`;
+      let run = `node ${scriptPath} ${this.uri} ${this.collection.collectionName}`;
       if (query) {
-        if (options?.fields) {
-          q = `${q}.find(${JSON.stringify(query)}, ${JSON.stringify(
-            options?.fields
-          )})`;
-        } else {
-          q = `${q}.find(${JSON.stringify(query)})`;
-        }
-      } else if (options?.fields) {
-        q = `${q}.find(${JSON.stringify({})}, ${JSON.stringify(
-          options?.fields
-        )})`;
-      } else {
-        q = `${q}.find()`;
+        const buffer: Buffer = Buffer.from(JSON.stringify(query));
+        run = `${run} ${buffer.toString('base64')}`;
+      }
+      if (options?.fields) {
+        if (!query) run = `${run} undefined`;
+        const buffer: Buffer = Buffer.from(JSON.stringify(options.fields));
+        run = `${run} ${buffer.toString('base64')}`;
       }
 
-      q = `${q}.toArray()`;
-      q = `JSON.stringify(${q})`;
-
-      const tmpfile = tmp.fileSync();
-      fs.writeFileSync(tmpfile.name, q);
-
-      const run = `mongo --quiet --host ${this.uri} < ${tmpfile.name}`;
-
-      let result = '';
+      let result;
       try {
         result = execSync(run, {
           encoding: 'utf8',
         });
       } catch (err) {
-        console.debug(`QUERY: ${q}`);
+        console.debug(`FIND COMMAND: ${run}`);
         console.error(err);
         throw err;
       }
 
-      const lines = result.split('\n');
-
-      let res: Array<Partial<T>> | undefined;
-      lines.some((l) => {
-        try {
-          res = JSON.parse(l);
-          return true;
-        } catch (err) {
-          return false;
-        }
-      });
-
-      return res;
+      return JSON.parse(result);
     });
 }

--- a/main/tests/MongoFind.js
+++ b/main/tests/MongoFind.js
@@ -1,0 +1,48 @@
+"use strict";
+
+var _mongodb = require("mongodb");
+
+const find = async (uri, collectionName, query, fields) => {
+  const connection = await _mongodb.MongoClient.connect(uri, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true
+  });
+
+  try {
+    const collection = connection.db().collection(collectionName);
+    let result;
+
+    if (fields) {
+      result = await collection.find(query).project(fields).toArray();
+    } else {
+      result = await collection.find(query).toArray();
+    }
+
+    return result;
+  } finally {
+    await connection.close();
+  }
+};
+
+const [uri, collectionName, query, fields] = process.argv.slice(2);
+let parsedQuery;
+
+if (query && query !== 'undefined') {
+  parsedQuery = JSON.parse(Buffer.from(query, 'base64').toString('utf8'));
+}
+
+let parsedFields;
+
+if (fields && fields !== 'undefined') {
+  parsedFields = JSON.parse(Buffer.from(fields, 'base64').toString('utf8'));
+}
+
+find(uri, collectionName, parsedQuery, parsedFields).then(result => {
+  // eslint-disable-next-line promise/always-return
+  const r = result ? JSON.stringify(result) : 'undefined';
+  process.stdout.write(r);
+  process.exit(0);
+}).catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/main/tests/MongoFind.ts
+++ b/main/tests/MongoFind.ts
@@ -1,0 +1,56 @@
+import { MongoClient } from 'mongodb';
+import type { FilterQuery } from 'mongodb';
+
+import type { MongoDoc } from '../src/types';
+
+const find = async <T extends MongoDoc>(
+  uri: string,
+  collectionName: string,
+  query?: FilterQuery<T>,
+  fields?: { [P in keyof T]: boolean | number }
+): Promise<Array<T> | undefined> => {
+  const connection = await MongoClient.connect(uri, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+
+  try {
+    const collection = connection.db().collection(collectionName);
+
+    let result;
+
+    if (fields) {
+      result = await collection.find(query).project(fields).toArray();
+    } else {
+      result = await collection.find(query).toArray();
+    }
+
+    return result;
+  } finally {
+    await connection.close();
+  }
+};
+
+const [uri, collectionName, query, fields] = process.argv.slice(2);
+
+let parsedQuery;
+if (query && query !== 'undefined') {
+  parsedQuery = JSON.parse(Buffer.from(query, 'base64').toString('utf8'));
+}
+
+let parsedFields;
+if (fields && fields !== 'undefined') {
+  parsedFields = JSON.parse(Buffer.from(fields, 'base64').toString('utf8'));
+}
+
+find(uri, collectionName, parsedQuery, parsedFields)
+  .then((result) => {
+    // eslint-disable-next-line promise/always-return
+    const r = result ? JSON.stringify(result) : 'undefined';
+    process.stdout.write(r);
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/main/tests/MongoMemoryReplSet.ts
+++ b/main/tests/MongoMemoryReplSet.ts
@@ -1,6 +1,13 @@
-import { Db, MongoClient } from 'mongodb';
-// @ts-ignore
-import { MongoMemoryReplSet as _MongoMemoryReplSet } from 'mongodb-memory-server';
+import { Mongo } from 'meteor/mongo';
+import { Collection, Db, MongoClient } from 'mongodb';
+import {
+  MongoMemoryReplSet as _MongoMemoryReplSet,
+  // @ts-ignore
+} from 'mongodb-memory-server';
+
+import { MongoDoc } from '../src/types';
+
+import { MeteorCollection } from './MeteorCollectionMock';
 
 let cleanup: (() => Promise<void> | void) | undefined;
 
@@ -69,6 +76,18 @@ class MongoMemoryReplSet {
       throw Error('no connection found, did you forget to call connect()?');
 
     return this.connection.db();
+  };
+
+  public mongoShell = async <T extends MongoDoc>(
+    collection: Collection<T>,
+    timeout = 2000
+  ): Promise<Mongo.Collection<T>> => {
+    const uri = await this.mongod.getUri();
+    return (new MeteorCollection<T>(
+      uri,
+      collection,
+      timeout
+    ) as unknown) as Mongo.Collection<T>;
   };
 }
 


### PR DESCRIPTION
This makes mocking mongo unnecessary. Mongo shell is used in order to be able to query synchronously.