### PR TITLE
feat: let resolvers run in the scope of the subscription

### DIFF
--- a/main/package-lock.json
+++ b/main/package-lock.json
@@ -156,9 +156,9 @@
 			}
 		},
 		"@types/meteor": {
-			"version": "1.4.49",
-			"resolved": "https://registry.npmjs.org/@types/meteor/-/meteor-1.4.49.tgz",
-			"integrity": "sha512-yWhDhmm+UOQOFgH4d6BBHhqrNeDpPQLOEVOCZYYRR7t2ZexcjTEgH7FmxQBhSDQbnVGTfTXrS+3h4wfx3FUMAg==",
+			"version": "1.4.62",
+			"resolved": "https://registry.npmjs.org/@types/meteor/-/meteor-1.4.62.tgz",
+			"integrity": "sha512-1CeYsg0M5qn1zzLY2mCf5BtdxhqMDqXApL7MuOt8jJuLaAnM4tm5gFTYLuawCWgrBCEX0X67RBqQRkgqpUrx1Q==",
 			"dev": true,
 			"requires": {
 				"@types/connect": "*",
@@ -190,9 +190,9 @@
 			"dev": true
 		},
 		"@types/react": {
-			"version": "16.9.49",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
-			"integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
+			"version": "16.9.55",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.55.tgz",
+			"integrity": "sha512-6KLe6lkILeRwyyy7yG9rULKJ0sXplUsl98MGoCfpteXf9sPWFWWMknDcsvubcpaTdBuxtsLF6HDUwdApZL/xIg==",
 			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
@@ -206,9 +206,9 @@
 			"dev": true
 		},
 		"@types/underscore": {
-			"version": "1.10.23",
-			"resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.10.23.tgz",
-			"integrity": "sha512-vX1NPekXhrLquFWskH2thcvFAha187F/lM6xYOoEMZWwJ/6alSk0/ttmGP/YRqcqtCv0TMbZjYAdZyHAEcuU4g==",
+			"version": "1.10.24",
+			"resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.10.24.tgz",
+			"integrity": "sha512-T3NQD8hXNW2sRsSbLNjF/aBo18MyJlbw0lSpQHB/eZZtScPdexN4HSa8cByYwTw9Wy7KuOFr81mlDQcQQaZ79w==",
 			"dev": true
 		},
 		"agent-base": {
@@ -399,9 +399,9 @@
 			}
 		},
 		"csstype": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-			"integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
+			"integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA==",
 			"dev": true
 		},
 		"date-fns": {

--- a/main/package.json
+++ b/main/package.json
@@ -42,7 +42,7 @@
     "mongodb": "^3.6.2"
   },
   "devDependencies": {
-    "@types/meteor": "^1.4.49",
+    "@types/meteor": "^1.4.62",
     "@types/mongodb": "^3.5.27",
     "concurrently": "^5.3.0",
     "minimongo": "^6.6.1",

--- a/main/src/PublicationContext.ts
+++ b/main/src/PublicationContext.ts
@@ -1,9 +1,10 @@
-import type { Meteor } from 'meteor/meteor';
+import type { Meteor, Subscription } from 'meteor/meteor';
 
 import ForeignKeyRegistry from './ForeignKeyRegistry';
 import { MongoDoc, WithoutId } from './types';
 
-export interface MeteorPublicationContext<T extends MongoDoc = MongoDoc> {
+export interface MeteorPublicationContext<T extends MongoDoc = MongoDoc>
+  extends Subscription {
   added(collection: string, id: string, doc: Partial<WithoutId<T>>): void;
   changed(collection: string, id: string, fields: Partial<WithoutId<T>>): void;
   connection: Meteor.Connection;
@@ -12,7 +13,7 @@ export interface MeteorPublicationContext<T extends MongoDoc = MongoDoc> {
   ready(): void;
   removed(collection: string, id: string): void;
   stop(): void;
-  userId: string | undefined;
+  userId: string | null;
   _subscriptionHandle?: string;
   _session?: {
     collectionViews: Map<
@@ -39,7 +40,7 @@ class PublicationContext<T extends MongoDoc = MongoDoc> {
 
   public readonly collectionName: string;
 
-  private readonly context: MeteorPublicationContext<T>;
+  public readonly context: MeteorPublicationContext<T>;
 
   private readonly skipPublication: boolean | undefined;
 

--- a/main/src/changeStream/ChangeStreamMultiplexer.ts
+++ b/main/src/changeStream/ChangeStreamMultiplexer.ts
@@ -12,10 +12,7 @@ import type {
   MongoDoc,
   StringOrObjectID,
 } from '../types';
-
-const bindEnvironment =
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  global.Meteor?.bindEnvironment || (<T = Function>(func: T): T => func);
+import bindEnvironment from '../utils/bindEnvironment';
 
 const STATIC_AGGREGATION_PIPELINE = [
   {

--- a/main/src/utils/bindEnvironment.ts
+++ b/main/src/utils/bindEnvironment.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/ban-types
+const bindEnvironment = <F extends Function>(func: F): F => {
+  return global.Meteor?.bindEnvironment<F>(func) || func;
+};
+
+export default bindEnvironment;

--- a/meteor-test-app/src/publications/Threads.ts
+++ b/meteor-test-app/src/publications/Threads.ts
@@ -11,6 +11,7 @@ Meteor.publish('threads', function threadsPublication() {
   console.log('threads publication started');
 
   const selector = {};
+  // @ts-ignore
   const root = new Link<ThreadDocument>(this, Threads, selector);
   root.link<Meteor.User>(Meteor.users, (doc) => doc?.userIds);
   root.observe();


### PR DESCRIPTION
This makes is possible to call this.userId in the resolver. In addition this fixes crashes when calling Meteor.userId() within a resolver.